### PR TITLE
Fix batch operation, second take

### DIFF
--- a/src/Service/SentimentsBatchService.php
+++ b/src/Service/SentimentsBatchService.php
@@ -148,13 +148,6 @@ final class SentimentsBatchService {
       '@max' => $context['sandbox']['total_entities'],
     ])->render();
 
-    // Calculate progress based on total entities processed vs total entities.
-    if ($context['sandbox']['total_entities'] > 0) {
-      $context['finished'] = $context['results']['processed'] / $context['sandbox']['total_entities'];
-    }
-    else {
-      $context['finished'] = 1;
-    }
   }
 
   /**

--- a/src/Service/SentimentsBatchService.php
+++ b/src/Service/SentimentsBatchService.php
@@ -99,8 +99,7 @@ final class SentimentsBatchService {
    *   Batch context.
    */
   public function processBatch(array $entities, bool $force_refresh, int $total_entities, array &$context): void {
-    if (!isset($context['sandbox']['total_entities'])) {
-      $context['sandbox']['total_entities'] = $total_entities;
+    if (!isset($context['results']['processed'])) {
       $context['results']['processed'] = 0;
       $context['results']['errors'] = [];
     }

--- a/src/Service/SentimentsBatchService.php
+++ b/src/Service/SentimentsBatchService.php
@@ -107,7 +107,7 @@ final class SentimentsBatchService {
 
     try {
       $analyzer = $this->analyzePluginManager
-        ->createInstance('ai_sentiments_analyzer');
+        ->createInstance('analyze_ai_sentiments_analyzer');
 
       foreach ($entities as $entity_data) {
         try {

--- a/src/Service/SentimentsBatchService.php
+++ b/src/Service/SentimentsBatchService.php
@@ -145,7 +145,7 @@ final class SentimentsBatchService {
 
     $context['message'] = $this->t('Processed @current of @max entities...', [
       '@current' => $context['results']['processed'],
-      '@max' => $context['sandbox']['total_entities'],
+      '@max' => $total_entities,
     ])->render();
 
   }


### PR DESCRIPTION
# Root cause

1. The plugin id was not found in the system registry.
2. A `PluginException` was thrown (and caught) that stopped the `$context['results']['processed']` from being incremented; this `processed` counter would remain set to 0.
3. The  `::processBatch()` method would then move to the handling of the `finished` state; there the value of the `processed` counter would be used to calculate and set the `finished` state to 0.
4. The method would reach its end and exit, informing the Batch API that the operation was not finished (`finished` state < 1); the Batch API would call the method again with the `sandbox` context preserved.
5. Upon calling the `::processBatch()` method again, the same conditions would apply, pluginNotFound => counterStuckOnZero => finishedStateStuckOnZero, that causing an infinite loop that would end up bringing MySQL down