### PR TITLE
Update PHPStan analysis to match dxpr_theme_helper approach

### DIFF
--- a/scripts/run-drupal-check.sh
+++ b/scripts/run-drupal-check.sh
@@ -1,38 +1,44 @@
 #!/bin/bash
+
 set -vo pipefail
 
-DRUPAL_RECOMMENDED_PROJECT=${DRUPAL_RECOMMENDED_PROJECT:-10.3.x-dev}
-PHP_EXTENSIONS="gd"
-DRUPAL_CHECK_TOOL="mglaman/drupal-check"
+# Install required libs for Drupal
+GD_ENABLED=$(php -i | grep 'GD Support' | awk '{ print $4 }')
 
-# Install required PHP extensions
-for ext in $PHP_EXTENSIONS; do
-  if ! php -m | grep -q $ext; then
-    apk update && apk add --no-cache ${ext}-dev
-    docker-php-ext-install $ext
-  fi
-done
-
-# Create Drupal project if it doesn't exist
-if [ ! -d "/drupal" ]; then
-  composer create-project drupal/recommended-project=$DRUPAL_RECOMMENDED_PROJECT drupal --no-interaction --stability=dev
+if [ "$GD_ENABLED" != 'enabled' ]; then
+  apk update && \
+  apk add libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev gd tree rsync && docker-php-ext-install gd
 fi
 
-cd drupal
+# Create project in a temporary directory inside the container
+INSTALL_DIR="/drupal_install_tmp"
+composer create-project drupal/recommended-project:11.x-dev "$INSTALL_DIR" --no-interaction --stability=dev
+
+cd "$INSTALL_DIR"
+
+# Allow specific plugins needed by dependencies before requiring them.
+composer config --no-plugins allow-plugins.tbachert/spi true --no-interaction
+
+# Create phpstan.neon config file
+cat <<EOF > phpstan.neon
+parameters:
+    paths:
+        - web/modules/contrib/analyze_ai_sentiments
+    # Set the analysis level (0-9)
+    level: 5
+EOF
+
 mkdir -p web/modules/contrib/
 
-# Symlink analyze_ai_brand_voice if not already linked
-if [ ! -L "web/modules/contrib/analyze_ai_brand_voice" ]; then
-  ln -s /src web/modules/contrib/analyze_ai_brand_voice
+if [ ! -L "web/modules/contrib/analyze_ai_sentiments" ]; then
+  ln -s /src web/modules/contrib/analyze_ai_sentiments
 fi
 
-# Install the statistic modules if D11 (removed from core).
-if [[ $DRUPAL_RECOMMENDED_PROJECT == 11.* ]]; then
-  composer require drupal/statistics
-fi
+# Install the statistics module if D11 (removed from core).
+composer require drupal/statistics --no-interaction
 
-# Install drupal-check
-composer require $DRUPAL_CHECK_TOOL --dev
+# Install PHPStan extensions for Drupal 11 and Drush for command analysis
+composer require --dev phpstan/phpstan mglaman/phpstan-drupal phpstan/phpstan-deprecation-rules drush/drush --with-all-dependencies --no-interaction
 
-# Run drupal-check
-./vendor/bin/drupal-check --drupal-root . -ad web/modules/contrib/analyze_ai_brand_voice 
+# Run phpstan
+./vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan.neon 


### PR DESCRIPTION
## Summary

- Switch from `mglaman/drupal-check` to direct PHPStan usage for consistency with dxpr_theme_helper
- Add inline `phpstan.neon` configuration with level 5 analysis
- Use same PHPStan extensions (phpstan/phpstan, mglaman/phpstan-drupal, phpstan/phpstan-deprecation-rules)
- Fix module symlink path to analyze_ai_sentiments (was incorrectly analyze_ai_brand_voice)
- Maintain Drupal 11 compatibility with statistics module requirement

## Test plan

- [x] Verify PHPStan analysis runs with new configuration
- [x] Confirm code quality standards compliance
- [x] Test Docker compose integration

This brings the analyze_ai_sentiments module's static analysis approach in line with dxpr_theme_helper for better maintainability across DXPR modules.

🤖 Generated with [Claude Code](https://claude.ai/code)